### PR TITLE
Fixed issue where container would fail due to missing cv2 dependency.

### DIFF
--- a/containerized/Dockerfile
+++ b/containerized/Dockerfile
@@ -1,8 +1,10 @@
 FROM tensorflow/tensorflow:latest-py3
 COPY . /server
+RUN apt-get update
 RUN apt-get --yes install libxext6
-RUN apt-get --yes install libsm6 libxrender1 libfontconfig1
+RUN apt-get --yes install libsm6 libxrender1 libfontconfig1 libgl1-mesa-glx
+RUN pip install --upgrade pip
 RUN pip install -r /server/requirements.txt
 EXPOSE 8080
 WORKDIR /server
-CMD flask run -h 0.0.0.0 -p 8080
+CMD ["flask", "run", "-h", "0.0.0.0", "-p", "8080"]


### PR DESCRIPTION
Update Dockerfile to update apt and install libgl1-mesa-glx for cv2. I also modified the CMD convention to use array syntax.